### PR TITLE
Enable build on non-windows by default

### DIFF
--- a/CrossCompatibility/build.ps1
+++ b/CrossCompatibility/build.ps1
@@ -12,7 +12,12 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$script:TargetFrameworks = 'netstandard2.0','net451'
+if ($IsWindows -eq $false) {
+    $script:TargetFrameworks = 'netstandard2.0'
+} else {
+    $script:TargetFrameworks = 'netstandard2.0','net451'
+}
+
 $script:BinModDir = Join-Path $PSScriptRoot 'CrossCompatibilityBinary'
 $script:BinModSrcDir = Join-Path $PSScriptRoot 'CrossCompatibility'
 


### PR DESCRIPTION
## PR Summary

If `-Framework` isn't specified, it tries building for .Net Framework which doesn't work on non-Windows.  Update to only built for netstandard20 if not on Windows.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.